### PR TITLE
Improve recommendations

### DIFF
--- a/lib/ex_assignment/todos.ex
+++ b/lib/ex_assignment/todos.ex
@@ -39,27 +39,6 @@ defmodule ExAssignment.Todos do
     end
   end
 
-  def sum_of_priorities(todos) do
-    todos = Enum.reverse todos
-    value2 = todos |> Enum.reduce(0, fn %{priority: priority}, sum -> priority + sum end) 
-    value = Enum.take_random(1..value2, 1) |> List.first() |> IO.inspect(label: "*********random value*****")
-    choose_todo(todos, value, value2)
-  end
-
-  defp choose_todo([%{title: title}], _, _) do
-    title
-  end
-
-  defp choose_todo([%{title: title, priority: _priority} | t], rand_value, acc) do
-    acc = acc - rand_value
-
-    if rand_value <= acc  do
-      title
-    else
-      choose_todo(t, rand_value, acc)
-    end
-  end
-
   @doc """
   Returns the next todo that is recommended to be done by the system.
 
@@ -69,7 +48,27 @@ defmodule ExAssignment.Todos do
     list_todos(:open)
     |> case do
       [] -> nil
-      todos -> Enum.take_random(todos, 1) |> List.first()
+      todos -> recommend_todo(todos)
+    end
+  end
+
+  #uses probability based on priority to recommend the next todo
+  defp recommend_todo(todos) do
+    randomized_value = todos |> Enum.reduce(0, fn %{priority: priority}, sum -> priority + sum end) |> :rand.uniform()
+    choose_todo(todos, randomized_value, 0)
+  end
+
+  defp choose_todo([todo], _, _), do: todo
+
+  defp choose_todo([todo | t], rand_value, acc) do
+    %{priority: priority} = todo
+
+    acc = acc - priority
+
+    if rand_value >= acc  do
+      todo
+    else
+      choose_todo(t, rand_value, acc)
     end
   end
 

--- a/lib/ex_assignment/todos.ex
+++ b/lib/ex_assignment/todos.ex
@@ -39,6 +39,27 @@ defmodule ExAssignment.Todos do
     end
   end
 
+  def sum_of_priorities(todos) do
+    todos = Enum.reverse todos
+    value2 = todos |> Enum.reduce(0, fn %{priority: priority}, sum -> priority + sum end) 
+    value = Enum.take_random(1..value2, 1) |> List.first() |> IO.inspect(label: "*********random value*****")
+    choose_todo(todos, value, value2)
+  end
+
+  defp choose_todo([%{title: title}], _, _) do
+    title
+  end
+
+  defp choose_todo([%{title: title, priority: _priority} | t], rand_value, acc) do
+    acc = acc - rand_value
+
+    if rand_value <= acc  do
+      title
+    else
+      choose_todo(t, rand_value, acc)
+    end
+  end
+
   @doc """
   Returns the next todo that is recommended to be done by the system.
 


### PR DESCRIPTION
Exercise 1

**Managed to do on this PR:**

1. Used probability based on todo item priority to recommend the next to do
2. Used the principle of the lowest priority number being the most urgent

**Hitches**

1. Got the solution working well for the inverse of the principle (high priority number representing high urgency) :(
2. When trying to tweak the solution I made the algo select the most urgent todo **but** with an 100% probability rate every time, like this:
    
![Screenshot from 2024-08-03 19-47-51](https://github.com/user-attachments/assets/496730ad-908c-4c31-81cb-7c4c1bd8e839)
  -This only means that the chance that `prepare lunch` (highest urgency), will be chosen over and over again is 100%
  - This may be an issue since my solution was to work on probability and not facts lol
  - The upside to this is that it actually fixes Exercise 2 without persistence, yes, a nice-to-have bug maybe? We know that the recommendation will always be the same even on browser restarts because of the 100% probability rate, only until we add a more urgent todo though.

3. I did not write tests for this functionality

**Assumptions**

- My assumptions in all this was that recommended todos should always be the most urgent

![improvegif](https://github.com/user-attachments/assets/c2d15598-0eb1-437a-bf47-1ec6e0618056)
